### PR TITLE
fix: show dates on all overview panels

### DIFF
--- a/scripts/national_team_position.py
+++ b/scripts/national_team_position.py
@@ -210,8 +210,12 @@ def make_charts(data, prices, out_dir):
         _draw(ax, g, dts, sh, pdf)
     fig.suptitle("国家队各宽基 ETF 份额 vs 指数走势（估计中央汇金持仓）",
                  fontsize=17, fontweight="bold")
-    fig.autofmt_xdate(rotation=45)
-    plt.tight_layout(rect=[0, 0, 1, 0.97])
+    # autofmt_xdate 会隐藏非底行子图的日期标签，逐轴设置确保六张图都显示
+    for ax in axes.flat:
+        ax.tick_params(axis="x", labelbottom=True, labelrotation=45)
+        for label in ax.get_xticklabels():
+            label.set_horizontalalignment("right")
+    fig.tight_layout(rect=[0, 0, 1, 0.97], h_pad=3.0)
     p = os.path.join(out_dir, "national_team_overview.png")
     plt.savefig(p, dpi=140); plt.close(fig)
     print(f"  总图 -> {p}")


### PR DESCRIPTION
## Summary

- keep date tick labels visible on all six overview panels
- rotate each subplot's labels explicitly instead of using `Figure.autofmt_xdate()`
- add vertical padding so the upper-row dates do not overlap the lower-row titles

## Root cause

Matplotlib's `Figure.autofmt_xdate()` hides x-axis tick labels on non-bottom rows in a multi-row subplot layout. In the 2x3 overview, this removed every date label from the upper three panels.

## Validation

- `python3 -m py_compile scripts/national_team_position.py`
- `git diff --check`
- synthetic regression check: visible date-label counts changed from `[0, 0, 0, 1, 1, 1]` before the fix to `[1, 1, 1, 1, 1, 1]` after it
- regenerated the real 3080x1540 overview and visually verified both rows at original resolution
